### PR TITLE
Upgrade Chromiun binary and flags to be 133

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oro-dxeco/playwright-aws-lambda",
-  "version": "119.0.3",
+  "version": "133.0.0-alpha.3",
   "description": "Support for running Microsoft's Playwrite on AWS Lambda and Google Cloud functions",
   "repository": {
     "type": "git",
@@ -26,7 +26,8 @@
     "format-code": "prettier --write '**/*.[jt]s'"
   },
   "dependencies": {
-    "@sparticuz/chromium": "^119.0.0",
+    "@sparticuz/chromium": "^133.0.0",
+    "@sparticuz/chromium-min": "^133.0.0",
     "lambdafs": "^2.1.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oro-dxeco/playwright-aws-lambda",
-  "version": "133.0.0-alpha.3",
+  "version": "133.0.0-alpha.4",
   "description": "Support for running Microsoft's Playwrite on AWS Lambda and Google Cloud functions",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oro-dxeco/playwright-aws-lambda",
-  "version": "133.0.0-alpha.4",
+  "version": "133.0.0",
   "description": "Support for running Microsoft's Playwrite on AWS Lambda and Google Cloud functions",
   "repository": {
     "type": "git",

--- a/src/chromium.ts
+++ b/src/chromium.ts
@@ -15,7 +15,7 @@ import getEnvironmentVariables, {
 } from './util/getEnvironmentVariables';
 import isLambdaRuntimeEnvironmentNode20 from './util/isLambdaRuntimeEnvironmentNode20';
 
-const { inflate } = require('lambdafs');
+import LambdaFS from '@sparticuz/chromium/build/lambdafs';
 
 /**
  * Returns a list of recommended additional Chromium flags.
@@ -90,16 +90,16 @@ async function getChromiumExecutablePath(
 
   const input = path.join(__dirname, 'bin');
   const promises = [
-    inflate(`${input}/chromium.br`),
-    inflate(`${input}/swiftshader.tar.br`),
+    LambdaFS.inflate(path.join(input, 'chromium.br')),
+    LambdaFS.inflate(path.join(input, 'swiftshader.tar.br')),
   ];
 
   if (isLambdaRuntimeEnvironment()) {
-    promises.push(inflate(`${input}/al2.tar.br`));
+    promises.push(LambdaFS.inflate(path.join(input, 'al2.tar.br')));
   }
 
   if (isLambdaRuntimeEnvironmentNode20()) {
-    promises.push(inflate(`${input}/al2023.tar.br`));
+    promises.push(LambdaFS.inflate(path.join(input, 'al2023.tar.br')));
   }
 
   const result = await Promise.all(promises);

--- a/src/util/getEnvironmentVariables.ts
+++ b/src/util/getEnvironmentVariables.ts
@@ -2,15 +2,16 @@ import { promises as fsPromises, existsSync } from 'fs';
 import * as path from 'path';
 
 import isLambdaRuntimeEnvironment from './isLambdaRuntimeEnvironment';
+import isLambdaRuntimeEnvironmentNode20 from './isLambdaRuntimeEnvironmentNode20';
 
 export const AWS_TMP_DIR = '/tmp/aws';
 export const AWS_FONT_DIR = '/tmp/fonts';
-const AWS_LIB_DIR = `${AWS_TMP_DIR}/lib`;
+//const AWS_LIB_DIR = `${AWS_TMP_DIR}/lib`;
 
-export default async function getEnvironmentVariables(): Promise<
-  Record<string, string>
-> {
-  if (!isLambdaRuntimeEnvironment()) {
+export default async function getEnvironmentVariables(
+  baselibPath: string
+): Promise<Record<string, string>> {
+  if (!isLambdaRuntimeEnvironment() && !isLambdaRuntimeEnvironmentNode20()) {
     return {};
   }
   const env: Record<string, string> = {};
@@ -34,10 +35,10 @@ export default async function getEnvironmentVariables(): Promise<
   }
 
   if (!process.env.LD_LIBRARY_PATH) {
-    env.LD_LIBRARY_PATH = AWS_LIB_DIR;
-  } else if (!process.env.LD_LIBRARY_PATH.startsWith(AWS_LIB_DIR)) {
+    env.LD_LIBRARY_PATH = baselibPath;
+  } else if (!process.env.LD_LIBRARY_PATH.startsWith(baselibPath)) {
     env.LD_LIBRARY_PATH = [
-      ...new Set([AWS_LIB_DIR, ...process.env.LD_LIBRARY_PATH.split(':')]),
+      ...new Set([baselibPath, ...process.env.LD_LIBRARY_PATH.split(':')]),
     ].join(':');
   }
   return env;

--- a/src/util/getEnvironmentVariables.ts
+++ b/src/util/getEnvironmentVariables.ts
@@ -6,7 +6,6 @@ import isLambdaRuntimeEnvironmentNode20 from './isLambdaRuntimeEnvironmentNode20
 
 export const AWS_TMP_DIR = '/tmp/aws';
 export const AWS_FONT_DIR = '/tmp/fonts';
-//const AWS_LIB_DIR = `${AWS_TMP_DIR}/lib`;
 
 export default async function getEnvironmentVariables(
   baselibPath: string

--- a/src/util/isLambdaRuntimeEnvironment.ts
+++ b/src/util/isLambdaRuntimeEnvironment.ts
@@ -5,7 +5,5 @@ export default function isLambdaRuntimeEnvironment(): boolean {
     'AWS_Lambda_nodejs14.x',
     'AWS_Lambda_nodejs16.x',
     'AWS_Lambda_nodejs18.x',
-    'AWS_Lambda_nodejs20.x',
-    'AWS_Lambda_nodejs22.x',
   ].includes(process.env.AWS_EXECUTION_ENV as string);
 }

--- a/src/util/isLambdaRuntimeEnvironmentNode20.ts
+++ b/src/util/isLambdaRuntimeEnvironmentNode20.ts
@@ -1,0 +1,5 @@
+export default function isLambdaRuntimeEnvironmentNode20(): boolean {
+  return ['AWS_Lambda_nodejs20.x', 'AWS_Lambda_nodejs22.x'].includes(
+    process.env.AWS_EXECUTION_ENV as string
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,13 +487,21 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sparticuz/chromium@^119.0.0":
-  version "119.0.0"
-  resolved "https://registry.yarnpkg.com/@sparticuz/chromium/-/chromium-119.0.0.tgz#00b0fa904bc4e88492980ecf7eb841aadb953227"
-  integrity sha512-wwc3E552woNUMBVDM57YGvxBTqpSSjtjeybZIgILsxAeqMKnQw0WYY6Aiy9NzUs2Dtf5Q6LS4emfDtTxntl4xA==
+"@sparticuz/chromium-min@^133.0.0":
+  version "133.0.0"
+  resolved "https://registry.yarnpkg.com/@sparticuz/chromium-min/-/chromium-min-133.0.0.tgz#df5a3ad854e3be39196c8e1481f4a7dcbbc30db7"
+  integrity sha512-7obk2CRitrlyxT4AKsCjSfE0QiHjDbi5GeOJirkerAZFV7o4VAsKzqoTQ/6rm3segZwfNFZzy8EdDelfV08aag==
   dependencies:
-    follow-redirects "^1.15.3"
-    tar-fs "^3.0.4"
+    follow-redirects "^1.15.9"
+    tar-fs "^3.0.8"
+
+"@sparticuz/chromium@^133.0.0":
+  version "133.0.0"
+  resolved "https://registry.yarnpkg.com/@sparticuz/chromium/-/chromium-133.0.0.tgz#515bb917d470828c0ffa5644eced95830f9ce83c"
+  integrity sha512-wioNxMtSxRI+Y6ymc/UFPX9lY7A1SDgBezjFITH6arwe5CONfWosNDGpgflUGYajxxGktb1k3kjJ83jWzbccBw==
+  dependencies:
+    follow-redirects "^1.15.9"
+    tar-fs "^3.0.8"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -819,9 +827,9 @@ aws4@^1.8.0:
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
 b4a@^1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.4.tgz#ef1c1422cae5ce6535ec191baeed7567443f36c9"
-  integrity sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.7.tgz#a99587d4ebbfbd5a6e3b21bdb5d5fa385767abe4"
+  integrity sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==
 
 babel-jest@^26.3.0:
   version "26.3.0"
@@ -887,6 +895,39 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+bare-events@^2.0.0, bare-events@^2.2.0:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.5.4.tgz#16143d435e1ed9eafd1ab85f12b89b3357a41745"
+  integrity sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==
+
+bare-fs@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-4.0.1.tgz#85844f34da819c76754d545323a8b23ed3617c76"
+  integrity sha512-ilQs4fm/l9eMfWY2dY0WCIUplSUp7U0CT1vrqMg1MUdeZl4fypu5UP0XcDBK5WBQPJAKP1b7XEodISmekH/CEg==
+  dependencies:
+    bare-events "^2.0.0"
+    bare-path "^3.0.0"
+    bare-stream "^2.0.0"
+
+bare-os@^3.0.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.6.0.tgz#1465dd7e1bebe0dec230097a23ad00f7db51f957"
+  integrity sha512-BUrFS5TqSBdA0LwHop4OjPJwisqxGy6JsWVqV6qaFoe965qqtaKfDzHY5T2YA1gUL0ZeeQeA+4BBc1FJTcHiPw==
+
+bare-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-3.0.0.tgz#b59d18130ba52a6af9276db3e96a2e3d3ea52178"
+  integrity sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==
+  dependencies:
+    bare-os "^3.0.1"
+
+bare-stream@^2.0.0:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.6.5.tgz#bba8e879674c4c27f7e27805df005c15d7a2ca07"
+  integrity sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==
+  dependencies:
+    streamx "^2.21.0"
 
 base64-js@^1.0.2:
   version "1.3.1"
@@ -1690,7 +1731,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-fifo@^1.1.0, fast-fifo@^1.2.0:
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
@@ -1758,10 +1799,10 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
-follow-redirects@^1.15.3:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+follow-redirects@^1.15.9:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3645,11 +3686,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-queue-tick@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142"
-  integrity sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==
-
 rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -4185,13 +4221,15 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-streamx@^2.15.0:
-  version "2.15.5"
-  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.15.5.tgz#87bcef4dc7f0b883f9359671203344a4e004c7f1"
-  integrity sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==
+streamx@^2.15.0, streamx@^2.21.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.22.0.tgz#cd7b5e57c95aaef0ff9b2aef7905afa62ec6e4a7"
+  integrity sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==
   dependencies:
-    fast-fifo "^1.1.0"
-    queue-tick "^1.0.1"
+    fast-fifo "^1.3.2"
+    text-decoder "^1.1.0"
+  optionalDependencies:
+    bare-events "^2.2.0"
 
 string-argv@0.3.1:
   version "0.3.1"
@@ -4316,14 +4354,16 @@ tar-fs@^2.1.1:
     pump "^3.0.0"
     tar-stream "^2.1.4"
 
-tar-fs@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.4.tgz#a21dc60a2d5d9f55e0089ccd78124f1d3771dbbf"
-  integrity sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==
+tar-fs@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.8.tgz#8f62012537d5ff89252d01e48690dc4ebed33ab7"
+  integrity sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==
   dependencies:
-    mkdirp-classic "^0.5.2"
     pump "^3.0.0"
     tar-stream "^3.1.5"
+  optionalDependencies:
+    bare-fs "^4.0.1"
+    bare-path "^3.0.0"
 
 tar-stream@^2.1.4:
   version "2.2.0"
@@ -4337,9 +4377,9 @@ tar-stream@^2.1.4:
     readable-stream "^3.1.1"
 
 tar-stream@^3.1.5:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.6.tgz#6520607b55a06f4a2e2e04db360ba7d338cc5bab"
-  integrity sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.7.tgz#24b3fb5eabada19fe7338ed6d26e5f7c482e792b"
+  integrity sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==
   dependencies:
     b4a "^1.6.4"
     fast-fifo "^1.2.0"
@@ -4366,6 +4406,13 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-decoder@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.3.tgz#b19da364d981b2326d5f43099c310cc80d770c65"
+  integrity sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==
+  dependencies:
+    b4a "^1.6.4"
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Copilot Summary

This pull request updates the Chromium integration for AWS Lambda and adds support for newer Node.js runtimes. The main changes include updating Chromium dependencies, improving runtime detection, and refining how environment variables and library paths are set for different Lambda environments.

**Dependency and compatibility updates:**

* Updated `@sparticuz/chromium` to version `^133.0.0` and added `@sparticuz/chromium-min` for improved support and compatibility. (`package.json`)
* Bumped the package version to `133.0.0` to reflect the new Chromium version. (`package.json`)

**Runtime environment detection and configuration:**

* Added a new utility `isLambdaRuntimeEnvironmentNode20` to detect Node.js 20.x and 22.x Lambda environments, and refactored code to use it for conditional logic. (`src/util/isLambdaRuntimeEnvironmentNode20.ts`, `src/chromium.ts`, `src/util/getEnvironmentVariables.ts`) [[1]](diffhunk://#diff-7768778eda77fc886cd47431b9302291f68fc618c8224b546c8d38636e5b1011R1-R5) [[2]](diffhunk://#diff-cdf7feba7484f97176d5a4c177304c0038778e76c55b8184858a26dcfacbe669R16-R18) [[3]](diffhunk://#diff-122d0779b7c70face6e145edc332603b064b19a379bb0bb6629d1e7429b7e703R5-R14)
* Refined the logic for setting the `LD_LIBRARY_PATH` environment variable, allowing dynamic selection of the base library path depending on the detected Lambda runtime. (`src/util/getEnvironmentVariables.ts`)

**Chromium launch and flags improvements:**

* Changed Chromium launch flags to use `--use-gl=angle`, `--use-angle=swiftshader`, and `--enable-unsafe-swiftshader` for better compatibility with the updated Chromium version. (`src/chromium.ts`)
* Adjusted the extraction of binary and library assets to support both AL2 and AL2023 Lambda environments, ensuring the correct libraries are inflated and available based on the runtime. (`src/chromium.ts`) [[1]](diffhunk://#diff-cdf7feba7484f97176d5a4c177304c0038778e76c55b8184858a26dcfacbe669L90-R102) [[2]](diffhunk://#diff-cdf7feba7484f97176d5a4c177304c0038778e76c55b8184858a26dcfacbe669R114-R121)

**Cleanup and refactoring:**

* Removed Node.js 20.x and 22.x from the legacy runtime detection utility to avoid overlap with the new dedicated detection function. (`src/util/isLambdaRuntimeEnvironment.ts`)