### PR TITLE
Upgrade Chromiun binary to be 143

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oro-dxeco/playwright-aws-lambda",
-  "version": "133.0.0",
+  "version": "143.0.0",
   "description": "Support for running Microsoft's Playwrite on AWS Lambda and Google Cloud functions",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 22.0.0"
   },
   "scripts": {
     "compile-src-cjs": "tsc --declaration --declarationDir ./dist -p tsconfig-src-cjs.json && shx cp -R ./node_modules/@sparticuz/chromium/bin ./dist/src",
@@ -26,9 +26,10 @@
     "format-code": "prettier --write '**/*.[jt]s'"
   },
   "dependencies": {
-    "@sparticuz/chromium": "^133.0.0",
-    "@sparticuz/chromium-min": "^133.0.0",
-    "lambdafs": "^2.1.1"
+    "@sparticuz/chromium": "^143.0.0",
+    "@sparticuz/chromium-min": "^143.0.0",
+    "lambdafs": "^2.1.1",
+    "tar-fs": "^3.1.1"
   },
   "peerDependencies": {
     "playwright-core": "^1"
@@ -36,7 +37,8 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.9",
-    "@types/node": "~14",
+    "@types/node": "^14.18.63",
+    "@types/tar-fs": "^2.0.4",
     "husky": "^4.2.5",
     "jest": "^26.3.0",
     "lint-staged": "10.2.11",
@@ -50,5 +52,9 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.9.7"
+  },
+  "volta": {
+    "node": "22.21.1",
+    "yarn": "1.22.22"
   }
 }

--- a/src/chromium.ts
+++ b/src/chromium.ts
@@ -15,7 +15,7 @@ import getEnvironmentVariables, {
 } from './util/getEnvironmentVariables';
 import isLambdaRuntimeEnvironmentNode20 from './util/isLambdaRuntimeEnvironmentNode20';
 
-import LambdaFS from '@sparticuz/chromium/build/lambdafs';
+import { inflate } from './util/inflate';
 
 /**
  * Returns a list of recommended additional Chromium flags.
@@ -90,16 +90,16 @@ async function getChromiumExecutablePath(
 
   const input = path.join(__dirname, 'bin');
   const promises = [
-    LambdaFS.inflate(path.join(input, 'chromium.br')),
-    LambdaFS.inflate(path.join(input, 'swiftshader.tar.br')),
+    inflate(path.join(input, 'chromium.br')),
+    inflate(path.join(input, 'swiftshader.tar.br')),
   ];
 
   if (isLambdaRuntimeEnvironment()) {
-    promises.push(LambdaFS.inflate(path.join(input, 'al2.tar.br')));
+    promises.push(inflate(path.join(input, 'al2.tar.br')));
   }
 
   if (isLambdaRuntimeEnvironmentNode20()) {
-    promises.push(LambdaFS.inflate(path.join(input, 'al2023.tar.br')));
+    promises.push(inflate(path.join(input, 'al2023.tar.br')));
   }
 
   const result = await Promise.all(promises);

--- a/src/util/inflate.ts
+++ b/src/util/inflate.ts
@@ -1,0 +1,76 @@
+import { createReadStream, createWriteStream, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { createBrotliDecompress, createUnzip } from 'node:zlib';
+import { extract } from 'tar-fs';
+/**
+ * Decompresses a (tarballed) Brotli or Gzip compressed file and returns the path to the decompressed file/folder.
+ *
+ * @param filePath Path of the file to decompress.
+ */
+export const inflate = (filePath: string): Promise<string> => {
+  // Determine the output path based on the file type
+  const output = filePath.includes('swiftshader')
+    ? tmpdir()
+    : join(
+        tmpdir(),
+        basename(filePath).replace(
+          /\.(?:t(?:ar(?:\.(?:br|gz))?|br|gz)|br|gz)$/i,
+          ''
+        )
+      );
+  return new Promise((resolve, reject) => {
+    // Quick return if the file is already decompressed
+    if (filePath.includes('swiftshader')) {
+      if (existsSync(`${output}/libGLESv2.so`)) {
+        resolve(output);
+        return;
+      }
+    } else if (existsSync(output)) {
+      resolve(output);
+      return;
+    }
+    // Optimize chunk size based on file type - use smaller chunks for better memory usage
+    // Brotli files tend to decompress to much larger sizes
+    const isBrotli = /br$/i.test(filePath);
+    const isGzip = /gz$/i.test(filePath);
+    const isTar = /\.t(?:ar(?:\.(?:br|gz))?|br|gz)$/i.test(filePath);
+    // Use a smaller highWaterMark for better memory efficiency
+    // For most serverless environments, 4MB (2**22) is more memory-efficient than 8MB
+    const highWaterMark = 2 ** 22;
+    const source = createReadStream(filePath, { highWaterMark });
+    let target;
+    // Setup error handlers first for both streams
+    const handleError = (error: Error) => {
+      reject(error);
+    };
+    source.once('error', handleError);
+    // Setup the appropriate target stream based on file type
+    if (isTar) {
+      target = extract(output);
+      target.once('finish', () => {
+        resolve(output);
+      });
+    } else {
+      target = createWriteStream(output, { mode: 0o700 });
+      target.once('close', () => {
+        resolve(output);
+      });
+    }
+    target.once('error', handleError);
+    // Pipe through the appropriate decompressor if needed
+    if (isBrotli || isGzip) {
+      // Use optimized chunk size for decompression
+      // 2MB (2**21) is sufficient for most brotli/gzip files
+      const decompressor = isBrotli
+        ? createBrotliDecompress({ chunkSize: 2 ** 21 })
+        : createUnzip({ chunkSize: 2 ** 21 });
+      // Handle decompressor errors
+      decompressor.once('error', handleError);
+      // Chain the streams
+      source.pipe(decompressor).pipe(target);
+    } else {
+      source.pipe(target);
+    }
+  });
+};

--- a/src/util/inflate.ts
+++ b/src/util/inflate.ts
@@ -3,6 +3,12 @@ import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { createBrotliDecompress, createUnzip } from 'node:zlib';
 import { extract } from 'tar-fs';
+
+/**
+ * Implementation based on:
+ * https://github.com/Sparticuz/chromium/blob/6c2f507c2d1dff618327f168ebdeb5011b712644/source/lambdafs.ts#L12
+ */
+
 /**
  * Decompresses a (tarballed) Brotli or Gzip compressed file and returns the path to the decompressed file/folder.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,21 +487,21 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sparticuz/chromium-min@^133.0.0":
-  version "133.0.0"
-  resolved "https://registry.yarnpkg.com/@sparticuz/chromium-min/-/chromium-min-133.0.0.tgz#df5a3ad854e3be39196c8e1481f4a7dcbbc30db7"
-  integrity sha512-7obk2CRitrlyxT4AKsCjSfE0QiHjDbi5GeOJirkerAZFV7o4VAsKzqoTQ/6rm3segZwfNFZzy8EdDelfV08aag==
+"@sparticuz/chromium-min@^143.0.0":
+  version "143.0.0"
+  resolved "https://registry.yarnpkg.com/@sparticuz/chromium-min/-/chromium-min-143.0.0.tgz#72d2719c7e7bc42f776f0ef09579fc4786f1bb46"
+  integrity sha512-B9nRt5kQi6q8wW+bmLlGqKC3VEulZgq3XWYAevK5B9ep3izIJGasIsVgczRvXuLeE9iGUQ8/dgSfNmC0/CbW/g==
   dependencies:
-    follow-redirects "^1.15.9"
-    tar-fs "^3.0.8"
+    follow-redirects "^1.15.11"
+    tar-fs "^3.1.1"
 
-"@sparticuz/chromium@^133.0.0":
-  version "133.0.0"
-  resolved "https://registry.yarnpkg.com/@sparticuz/chromium/-/chromium-133.0.0.tgz#515bb917d470828c0ffa5644eced95830f9ce83c"
-  integrity sha512-wioNxMtSxRI+Y6ymc/UFPX9lY7A1SDgBezjFITH6arwe5CONfWosNDGpgflUGYajxxGktb1k3kjJ83jWzbccBw==
+"@sparticuz/chromium@^143.0.0":
+  version "143.0.0"
+  resolved "https://registry.yarnpkg.com/@sparticuz/chromium/-/chromium-143.0.0.tgz#f98844e621baf17b347b7f2ffc948e3168cb919f"
+  integrity sha512-/vvplFwu1yDNt/Q1uwXQUwxmfZutU9K+WtzSYwptLWV8IeSdSF6vwW9hW11fZA8Gl9+2mytAGUe6/otgd2VeXA==
   dependencies:
-    follow-redirects "^1.15.9"
-    tar-fs "^3.0.8"
+    follow-redirects "^1.15.11"
+    tar-fs "^3.1.1"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -595,10 +595,15 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/node@*", "@types/node@~14":
+"@types/node@*":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+
+"@types/node@^14.18.63":
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -619,6 +624,21 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/tar-fs@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tar-fs/-/tar-fs-2.0.4.tgz#7c7502d281d436db0ad0f78282acef71da02a292"
+  integrity sha512-ipPec0CjTmVDWE+QKr9cTmIIoTl7dFG/yARCM5MqK8i6CNLIG1P8x4kwDsOQY1ChZOZjH0wO9nvfgBvWl4R3kA==
+  dependencies:
+    "@types/node" "*"
+    "@types/tar-stream" "*"
+
+"@types/tar-stream@*":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/tar-stream/-/tar-stream-3.1.4.tgz#7eca21004291f8d4803437fe20cc01b0744782a8"
+  integrity sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1799,10 +1819,10 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
-follow-redirects@^1.15.9:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+follow-redirects@^1.15.11:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -4354,10 +4374,10 @@ tar-fs@^2.1.1:
     pump "^3.0.0"
     tar-stream "^2.1.4"
 
-tar-fs@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.8.tgz#8f62012537d5ff89252d01e48690dc4ebed33ab7"
-  integrity sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==
+tar-fs@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
+  integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION

This pull request updates the package to support newer versions of Chromium and Node.js, introduces a custom decompression utility, and adjusts dependencies accordingly. The main goal is to modernize the environment requirements and improve how compressed files are handled, especially for serverless deployments.

**Dependency and environment updates:**

- Updated the package version to `143.0.0` and bumped `@sparticuz/chromium` and `@sparticuz/chromium-min` dependencies to `^143.0.0`, ensuring compatibility with the latest Chromium builds. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R41)
- Increased the minimum required Node.js version to `>= 22.0.0` and added a `volta` configuration to enforce Node.js and Yarn versions for development. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R55-R58)

**Decompression and file handling improvements:**

- Replaced the use of `LambdaFS.inflate` with a new local `inflate` utility for decompressing `.br` and `.tar.br` files, improving control over the decompression process. [[1]](diffhunk://#diff-cdf7feba7484f97176d5a4c177304c0038778e76c55b8184858a26dcfacbe669L18-R18) [[2]](diffhunk://#diff-cdf7feba7484f97176d5a4c177304c0038778e76c55b8184858a26dcfacbe669L93-R102)
- Added a new `inflate.ts` utility that handles Brotli and gzip decompression, tar extraction, and optimizes memory usage for serverless environments.
- Added `tar-fs` and its type definitions as dependencies to support tar extraction in the new inflate utility.

**Development dependency updates:**

- Updated `@types/node` to a more recent version and added `@types/tar-fs` for improved type safety and compatibility.